### PR TITLE
Add YarsiiBot: Node.js AI chatbot with web UI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+OPENAI_API_KEY=tu_api_key_aqui
+OPENAI_MODEL=gpt-5.5
+PORT=3000

--- a/README.md
+++ b/README.md
@@ -1,2 +1,35 @@
-# Yarsii
-Tecnología
+# YarsiiBot
+
+Chatbot web en español con inteligencia artificial usando Node.js y la API de OpenAI.
+
+## Requisitos
+
+- Node.js 20 o superior.
+- Una API key de OpenAI.
+
+## Instalación
+
+```bash
+cp .env.example .env
+```
+
+Edita `.env` y coloca tu clave real en `OPENAI_API_KEY`.
+
+## Ejecutar
+
+```bash
+OPENAI_API_KEY=tu_api_key_aqui npm start
+```
+
+Abre <http://localhost:3000> en tu navegador.
+
+## Modo demo
+
+Si no configuras `OPENAI_API_KEY`, la interfaz funciona en modo demo y muestra un mensaje indicando cómo activar la IA real.
+
+## Archivos principales
+
+- `server.js`: servidor Node.js y endpoint `/api/chat` que llama a OpenAI Responses API.
+- `public/index.html`: estructura de la interfaz del chat.
+- `public/styles.css`: diseño visual responsive.
+- `public/app.js`: lógica del chat en el navegador.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "yarsii-ai-chatbot",
+  "version": "1.0.0",
+  "description": "Chatbot web con IA usando OpenAI Responses API.",
+  "type": "module",
+  "scripts": {
+    "start": "node server.js",
+    "check": "node --check server.js && node --check public/app.js"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "license": "MIT"
+}

--- a/public/app.js
+++ b/public/app.js
@@ -1,0 +1,56 @@
+const form = document.querySelector("#chat-form");
+const input = document.querySelector("#message-input");
+const messagesContainer = document.querySelector("#messages");
+const statusElement = document.querySelector("#status");
+const messages = [];
+
+function addMessage(role, content, extraClass = "") {
+  messages.push({ role, content });
+  const bubble = document.createElement("div");
+  bubble.className = `message ${role} ${extraClass}`.trim();
+  bubble.textContent = content;
+  messagesContainer.append(bubble);
+  messagesContainer.scrollTop = messagesContainer.scrollHeight;
+}
+
+async function checkHealth() {
+  try {
+    const response = await fetch("/api/health");
+    const health = await response.json();
+    statusElement.textContent = health.aiEnabled
+      ? `IA activa · Modelo ${health.model}`
+      : "Modo demo · Falta configurar OPENAI_API_KEY";
+  } catch {
+    statusElement.textContent = "Servidor no disponible";
+  }
+}
+
+form.addEventListener("submit", async (event) => {
+  event.preventDefault();
+  const text = input.value.trim();
+  if (!text) return;
+
+  addMessage("user", text);
+  input.value = "";
+  form.querySelector("button").disabled = true;
+
+  try {
+    const response = await fetch("/api/chat", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ messages }),
+    });
+    const data = await response.json();
+
+    if (!response.ok) throw new Error(data.error || "Error desconocido");
+    addMessage("assistant", data.reply);
+  } catch (error) {
+    addMessage("assistant", error.message, "error");
+  } finally {
+    form.querySelector("button").disabled = false;
+    input.focus();
+  }
+});
+
+addMessage("assistant", "¡Hola! Soy YarsiiBot. ¿En qué puedo ayudarte hoy?");
+checkHealth();

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>YarsiiBot | Chatbot con IA</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="chat-shell">
+      <section class="hero">
+        <p class="eyebrow">Chatbot con inteligencia artificial</p>
+        <h1>YarsiiBot</h1>
+        <p>Escribe una pregunta y conversa con tu asistente en español.</p>
+      </section>
+
+      <section class="chat-card" aria-label="Chat con YarsiiBot">
+        <div id="status" class="status">Conectando...</div>
+        <div id="messages" class="messages" aria-live="polite"></div>
+        <form id="chat-form" class="chat-form">
+          <label class="sr-only" for="message-input">Mensaje</label>
+          <input id="message-input" name="message" type="text" placeholder="Pregunta algo..." autocomplete="off" required />
+          <button type="submit">Enviar</button>
+        </form>
+      </section>
+    </main>
+
+    <script src="app.js" type="module"></script>
+  </body>
+</html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,0 +1,111 @@
+:root {
+  color-scheme: dark;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: radial-gradient(circle at top left, #2563eb 0, transparent 32rem), #0f172a;
+}
+
+.chat-shell {
+  width: min(960px, 92vw);
+  display: grid;
+  grid-template-columns: 0.9fr 1.1fr;
+  gap: 2rem;
+  align-items: center;
+}
+
+.hero h1 {
+  margin: 0 0 1rem;
+  font-size: clamp(3rem, 7vw, 5.5rem);
+  line-height: 0.95;
+}
+
+.hero p { color: #cbd5e1; font-size: 1.1rem; }
+.eyebrow { color: #93c5fd !important; font-weight: 700; text-transform: uppercase; letter-spacing: 0.08em; }
+
+.chat-card {
+  min-height: 620px;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 28px;
+  background: rgba(15, 23, 42, 0.78);
+  box-shadow: 0 24px 80px rgba(2, 6, 23, 0.45);
+  backdrop-filter: blur(18px);
+}
+
+.status {
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+  color: #93c5fd;
+  font-size: 0.9rem;
+}
+
+.messages {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  padding: 1.25rem;
+  overflow-y: auto;
+}
+
+.message {
+  max-width: 82%;
+  padding: 0.85rem 1rem;
+  border-radius: 18px;
+  line-height: 1.45;
+  white-space: pre-wrap;
+}
+
+.message.user { align-self: flex-end; background: #2563eb; color: white; border-bottom-right-radius: 4px; }
+.message.assistant { align-self: flex-start; background: #1e293b; border-bottom-left-radius: 4px; }
+.message.error { background: #7f1d1d; color: #fecaca; }
+
+.chat-form {
+  display: flex;
+  gap: 0.75rem;
+  padding: 1rem;
+  border-top: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+input, button {
+  border: 0;
+  border-radius: 999px;
+  font: inherit;
+}
+
+input {
+  flex: 1;
+  min-width: 0;
+  padding: 0.95rem 1rem;
+  background: #020617;
+  color: #e2e8f0;
+  outline: 1px solid rgba(148, 163, 184, 0.35);
+}
+
+button {
+  padding: 0.95rem 1.25rem;
+  background: #22c55e;
+  color: #052e16;
+  font-weight: 800;
+  cursor: pointer;
+}
+
+button:disabled { cursor: wait; opacity: 0.7; }
+.sr-only { position: absolute; width: 1px; height: 1px; overflow: hidden; clip: rect(0, 0, 0, 0); }
+
+@media (max-width: 780px) {
+  .chat-shell { grid-template-columns: 1fr; padding: 2rem 0; }
+  .chat-card { min-height: 70vh; }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,114 @@
+import { createServer } from "node:http";
+import { readFile } from "node:fs/promises";
+import { extname, join, normalize } from "node:path";
+
+const port = process.env.PORT || 3000;
+const model = process.env.OPENAI_MODEL || "gpt-5.5";
+const publicDir = join(process.cwd(), "public");
+
+const mimeTypes = {
+  ".html": "text/html; charset=utf-8",
+  ".css": "text/css; charset=utf-8",
+  ".js": "text/javascript; charset=utf-8",
+};
+
+function sendJson(response, statusCode, payload) {
+  response.writeHead(statusCode, { "Content-Type": "application/json; charset=utf-8" });
+  response.end(JSON.stringify(payload));
+}
+
+async function readJsonBody(request) {
+  const chunks = [];
+  for await (const chunk of request) chunks.push(chunk);
+  return JSON.parse(Buffer.concat(chunks).toString("utf8") || "{}");
+}
+
+function cleanMessages(messages) {
+  if (!Array.isArray(messages)) return [];
+
+  return messages
+    .filter((message) => ["user", "assistant"].includes(message.role) && typeof message.content === "string")
+    .slice(-12)
+    .map((message) => ({ role: message.role, content: message.content.slice(0, 2000) }));
+}
+
+async function askOpenAI(messages) {
+  const response = await fetch("https://api.openai.com/v1/responses", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model,
+      instructions:
+        "Eres YarsiiBot, un asistente amable que responde en español claro, breve y útil. Si no sabes algo, dilo y pide más contexto.",
+      input: messages,
+    }),
+  });
+
+  const data = await response.json();
+  if (!response.ok) throw new Error(data.error?.message || "OpenAI no respondió correctamente.");
+  return data.output_text || "No pude generar una respuesta. Inténtalo de nuevo.";
+}
+
+async function handleChat(request, response) {
+  try {
+    const body = await readJsonBody(request);
+    const messages = cleanMessages(body.messages);
+    const lastUserMessage = messages.findLast((message) => message.role === "user");
+
+    if (!lastUserMessage) {
+      return sendJson(response, 400, { error: "Escribe un mensaje para conversar con el bot." });
+    }
+
+    if (!process.env.OPENAI_API_KEY) {
+      return sendJson(response, 200, {
+        reply:
+          "Modo demo: configura OPENAI_API_KEY en el servidor para activar respuestas reales con IA. Mientras tanto, puedo ayudarte a probar la interfaz.",
+      });
+    }
+
+    const reply = await askOpenAI(messages);
+    return sendJson(response, 200, { reply });
+  } catch (error) {
+    console.error("Chat request failed", error);
+    return sendJson(response, 500, { error: "No pude conectarme con la IA. Revisa la API key o intenta más tarde." });
+  }
+}
+
+async function serveStatic(pathname, response) {
+  const requestedPath = pathname === "/" ? "/index.html" : pathname;
+  const safePath = normalize(decodeURIComponent(requestedPath)).replace(/^\.\.(\/|\\|$)/, "");
+  const filePath = join(publicDir, safePath);
+
+  try {
+    const file = await readFile(filePath);
+    response.writeHead(200, { "Content-Type": mimeTypes[extname(filePath)] || "application/octet-stream" });
+    response.end(file);
+  } catch {
+    sendJson(response, 404, { error: "Archivo no encontrado." });
+  }
+}
+
+const server = createServer(async (request, response) => {
+  const url = new URL(request.url, `http://${request.headers.host}`);
+
+  if (request.method === "GET" && url.pathname === "/api/health") {
+    return sendJson(response, 200, { ok: true, aiEnabled: Boolean(process.env.OPENAI_API_KEY), model });
+  }
+
+  if (request.method === "POST" && url.pathname === "/api/chat") {
+    return handleChat(request, response);
+  }
+
+  if (request.method === "GET") {
+    return serveStatic(url.pathname, response);
+  }
+
+  return sendJson(response, 405, { error: "Método no permitido." });
+});
+
+server.listen(port, () => {
+  console.log(`YarsiiBot listo en http://localhost:${port}`);
+});


### PR DESCRIPTION
### Motivation
- Provide a simple Spanish AI chatbot web app for the repository that can call the OpenAI Responses API when an API key is configured.
- Ship a minimal, dependency-light server and a responsive static chat UI so the project is easy to run and extend.
- Include configuration and docs to make local testing and later integration with OpenAI straightforward.

### Description
- Add `server.js` implementing a lightweight Node HTTP server with `/api/health` and `/api/chat`, sanitizing message history and calling the Responses API when `OPENAI_API_KEY` is present.
- Add a static frontend under `public/` with `index.html`, `styles.css`, and `app.js` to provide a responsive Spanish chat UI and client-side chat logic.
- Add `package.json` with `start` and `check` scripts, `.env.example` for environment variables, and update `README.md` with setup and run instructions.

### Testing
- Ran syntax checks with `npm run check` (which runs `node --check server.js` and `node --check public/app.js`) and they succeeded.
- Started the server with `npm start` and queried the health endpoint with `curl http://localhost:3000/api/health`, which returned HTTP 200 and JSON `{ ok: true, aiEnabled: false, model: "gpt-5.5" }`.
- Attempted `npm install` to fetch the OpenAI SDK earlier, but the install failed with a `403` from the npm registry during an automated run, so no SDK was installed in the environment during testing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a313b782da08320ae9694ef913d28c4)